### PR TITLE
Add 10% padding to text height

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artano"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["J/A <archer884@gmail.com>"]
 license = "MIT/Apache-2.0"
 keywords = ["image", "image-manipulation", "meme", "pepe", "kek"]

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -265,7 +265,7 @@ fn font_height(font: &Font, scale: Scale) -> u32 {
     use rusttype::VMetrics;
 
     let VMetrics { ascent, descent, .. } = font.v_metrics(scale);
-    (ascent - descent) as u32
+    ((ascent - descent) as f32 * 1.1) as u32
 }
 
 fn calculate_text_width(s: &str, font: &Font, scale: Scale) -> u32 {


### PR DESCRIPTION
We had an issue where the border at the tip of some dangly letters (like y) was being cut off because it lay outside the bounding box for the rendered text. This change rather ham-fistedly increases the size of the bounding box.