### PR TITLE
upgrade nalgebra indirectly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ Adds text to pictures.
 
 [dependencies]
 conv = "0.3"
-image = "0.19"
-imageproc = "0.15"
-rusttype = "0.6"
+image = "0.20.0"
+imageproc = "0.16.0"
+rusttype = "0.7.2"

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,6 +1,6 @@
 use annotation::Annotation;
 use error::Result;
-use image::{self, imageops, DynamicImage, FilterType, GenericImage, ImageOutputFormat, RgbaImage};
+use image::{self, imageops, DynamicImage, FilterType, GenericImageView, ImageOutputFormat, RgbaImage};
 use rusttype::Font;
 use std::io;
 


### PR DESCRIPTION
This and annatar is caught up in rust-lang/rust#49799, and `imageproc` has had a new release. Please update annatar too once you release this too. I have compiled annatar with this branch (though I hit the unimplemented font_path code path).